### PR TITLE
google api-clientの読み方が変わっていたので、バージョンを固定

### DIFF
--- a/gcevent.gemspec
+++ b/gcevent.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "google-api-client"
+  spec.add_dependency "google-api-client", "0.8.6"
   spec.add_dependency "activesupport"
   spec.add_dependency "hashie"
 


### PR DESCRIPTION
実装時に利用していたバージョンで固定。
アップデート対応は別バージョンで行う。